### PR TITLE
Include biscuit_bg.js in esm distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "files": [
     "module/biscuit_bg.wasm",
     "module/biscuit.js",
+    "module/biscuit_bg.js",
     "module/biscuit.d.ts",
     "module/snippets",
     "dist/biscuit_bg.wasm",


### PR DESCRIPTION
Currently missing

```
> rollup -c

index.js → dist/index.js...
[!] Error: Could not resolve './biscuit_bg.js' from node_modules/@biscuit-auth/biscuit-wasm/module/biscuit.js
Error: Could not resolve './biscuit_bg.js' from node_modules/@biscuit-auth/biscuit-wasm/module/biscuit.js
```