### PR TITLE
Fix public constructor for BiscuitBuilder + clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,10 +90,9 @@ impl Biscuit {
     /// Serializes to URL safe base 64 data
     #[wasm_bindgen(js_name = toBase64)]
     pub fn to_base64(&self) -> Result<String, JsValue> {
-        Ok(self
-            .0
+        self.0
             .to_base64()
-            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())?)
+            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
     /// Returns the list of revocation identifiers, encoded as URL safe base 64
@@ -117,10 +116,9 @@ impl Biscuit {
     /// Prints a block's content as Datalog code
     #[wasm_bindgen(js_name = getBlockSource)]
     pub fn block_source(&self, index: usize) -> Result<String, JsValue> {
-        Ok(self
-            .0
+        self.0
             .print_block_source(index)
-            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())?)
+            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
     /// Creates a third party request
@@ -267,9 +265,9 @@ impl Authorizer {
                 .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())?;
         }
 
-        Ok(authorizer
+        authorizer
             .authorize()
-            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())?)
+            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 }
 
@@ -308,10 +306,9 @@ impl ThirdPartyRequest {
 
     /// Serializes to URL safe base 64 data
     pub fn to_base64(&self) -> Result<String, JsValue> {
-        Ok(self
-            .0
+        self.0
             .serialize_base64()
-            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())?)
+            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
     /// creates a ThirdPartyBlock from a BlockBuilder and the
@@ -363,10 +360,9 @@ impl ThirdPartyBlock {
 
     /// Serializes to URL safe base 64 data
     pub fn to_base64(self) -> Result<String, JsValue> {
-        Ok(self
-            .0
+        self.0
             .serialize_base64()
-            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())?)
+            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 }
 
@@ -377,7 +373,7 @@ pub struct BiscuitBuilder(biscuit::builder::BiscuitBuilder);
 #[wasm_bindgen]
 impl BiscuitBuilder {
     #[wasm_bindgen(constructor)]
-    fn new() -> BiscuitBuilder {
+    pub fn new() -> BiscuitBuilder {
         BiscuitBuilder(biscuit::builder::BiscuitBuilder::new())
     }
 
@@ -476,19 +472,17 @@ impl BlockBuilder {
     /// Adds a Datalog fact
     #[wasm_bindgen(js_name = addFact)]
     pub fn add_fact(&mut self, fact: Fact) -> Result<(), JsValue> {
-        Ok(self
-            .0
+        self.0
             .add_fact(fact.0)
-            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())?)
+            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
     /// Adds a Datalog rule
     #[wasm_bindgen(js_name = addRule)]
     pub fn add_rule(&mut self, rule: Rule) -> Result<(), JsValue> {
-        Ok(self
-            .0
+        self.0
             .add_rule(rule.0)
-            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())?)
+            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
     /// Adds a check
@@ -496,10 +490,9 @@ impl BlockBuilder {
     /// All checks, from authorizer and token, must be validated to authorize the request
     #[wasm_bindgen(js_name = addCheck)]
     pub fn add_check(&mut self, check: Check) -> Result<(), JsValue> {
-        Ok(self
-            .0
+        self.0
             .add_check(check.0)
-            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())?)
+            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
     /// Adds facts, rules, checks and policies as one code block
@@ -727,7 +720,7 @@ impl PublicKey {
     /// Serializes a public key to a hexadecimal string
     #[wasm_bindgen(js_name = toString)]
     pub fn to_hex(&self) -> String {
-        hex::encode(&self.0.to_bytes())
+        hex::encode(self.0.to_bytes())
     }
 
     /// Deserializes a public key from raw bytes
@@ -784,10 +777,7 @@ impl<'de> Visitor<'de> for PublicKeyVisitor {
             )),
             Some(s) => match biscuit::PublicKey::from_bytes_hex(s) {
                 Ok(pk) => Ok(PublicKey(pk)),
-                Err(e) => Err(E::custom(format!(
-                    "could not parse public key: {}",
-                    e.to_string()
-                ))),
+                Err(e) => Err(E::custom(format!("could not parse public key: {}", e))),
             },
         }
     }
@@ -822,7 +812,7 @@ impl PrivateKey {
     /// Serializes a private key to a hexadecimal string
     #[wasm_bindgen(js_name = toString)]
     pub fn to_hex(&self) -> String {
-        hex::encode(&self.0.to_bytes())
+        hex::encode(self.0.to_bytes())
     }
 
     /// Deserializes a private key from raw bytes


### PR DESCRIPTION
- I don't know whether it was intended or not, but there is a missing `pub` for `BiscuitBuilder` constructor
- easy clippy fixes.