### PR TITLE
Add a simple CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+     steps:
+      - uses: actions/checkout@v3
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-
+      - uses: jetli/wasm-pack-action@v0.4.0
+        name: Install wasm-pack
+        with:
+          version: 'latest'
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /dist
 /module
+package-lock.json


### PR DESCRIPTION
My goal is to add e2e tests for Node.JS part.
This include a CI with Github actions and write some basic tests with Jest.

First step is to setup a simple CI that just run `build` script