### PR TITLE
Add support for `fact`, `rule`, `check` and `policy` tagged templates

### DIFF
--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -1,4 +1,4 @@
-import  {Biscuit, PrivateKey, KeyPair, Fact, Rule, biscuit, authorizer, block} from '@biscuit-auth/biscuit-wasm';
+import  {Biscuit, PrivateKey, KeyPair, Fact, Rule, biscuit, authorizer, block, rule} from '@biscuit-auth/biscuit-wasm';
 // necessary for esm support, see https://docs.rs/getrandom/latest/getrandom/#nodejs-es-module-support
 import { webcrypto } from 'node:crypto'
 
@@ -41,7 +41,10 @@ let policy = auth.authorize();
 console.log("Authorized the token with the provided rules");
 console.log("matched policy: "+ policy);
 
-let facts = auth.query(Rule.fromString("u($id) <- user($id)"));
+let otherKeyPair = new KeyPair();
+let r =  rule`u($id) <- user($id), $id == ${id} trusting authority, ${otherKeyPair.getPublicKey()}`;
+console.log(r.toString());
+let facts = auth.query(r);
 console.log("Queried the token (and the authorization context) and got the following results");
 
 for(let f of facts) {

--- a/snippets/definitions/tagged-templates.d.ts
+++ b/snippets/definitions/tagged-templates.d.ts
@@ -20,9 +20,30 @@ export function block(strings: string[], ...values: any[]): BlockBuilder;
  */
 export function authorizer(strings: string[], ...values: any[]): Authorizer;
 /**
+ * Tagged template generating a fact from datalog code
+ *
+ * @param {string[]} strings
+ * @param {any[]} values
+ */
+export function fact(strings: string[], ...values: any[]): Fact;
+/**
  * Tagged template generating a rule from datalog code
  *
  * @param {string[]} strings
  * @param {any[]} values
  */
 export function rule(strings: string[], ...values: any[]): Rule;
+/**
+ * Tagged template generating a check from datalog code
+ *
+ * @param {string[]} strings
+ * @param {any[]} values
+ */
+export function check(strings: string[], ...values: any[]): Check;
+/**
+ * Tagged template generating a policy from datalog code
+ *
+ * @param {string[]} strings
+ * @param {any[]} values
+ */
+export function policy(strings: string[], ...values: any[]): Policy;

--- a/snippets/definitions/tagged-templates.d.ts
+++ b/snippets/definitions/tagged-templates.d.ts
@@ -19,3 +19,10 @@ export function block(strings: string[], ...values: any[]): BlockBuilder;
  * @param {any[]} values
  */
 export function authorizer(strings: string[], ...values: any[]): Authorizer;
+/**
+ * Tagged template generating a rule from datalog code
+ *
+ * @param {string[]} strings
+ * @param {any[]} values
+ */
+export function rule(strings: string[], ...values: any[]): Rule;

--- a/snippets/tagged-templates.js
+++ b/snippets/tagged-templates.js
@@ -1,4 +1,11 @@
-import { Biscuit, Authorizer, Rule } from "./biscuit_bg.js";
+import {
+  Biscuit,
+  Authorizer,
+  Rule,
+  Fact,
+  Check,
+  Policy,
+} from "./biscuit_bg.js";
 
 function prepareTerm(value) {
   if (value instanceof Date) {
@@ -62,6 +69,31 @@ export function authorizer(strings, ...values) {
   return tagged(builder)(strings, ...values);
 }
 
+export function fact(strings, ...values) {
+  let code = "";
+  for (let i = 0; i < strings.length; i++) {
+    code += strings[i];
+    if (i < values.length) {
+      code += `{_param_${i}}`;
+    }
+  }
+
+  const params = new Map(
+    values.map((v, i) => {
+      return [`_param_${i}`, prepareTerm(v)];
+    })
+  );
+
+  const f = Fact.fromString(code);
+  const unboundParams = f.unboundParameters();
+
+  for (let p of unboundParams) {
+    f.set(p, params.get(p));
+  }
+
+  return f;
+}
+
 export function rule(strings, ...values) {
   let code = "";
   for (let i = 0; i < strings.length; i++) {
@@ -90,4 +122,64 @@ export function rule(strings, ...values) {
   }
 
   return r;
+}
+
+export function check(strings, ...values) {
+  let code = "";
+  for (let i = 0; i < strings.length; i++) {
+    code += strings[i];
+    if (i < values.length) {
+      code += `{_param_${i}}`;
+    }
+  }
+
+  const params = new Map(
+    values.map((v, i) => {
+      return [`_param_${i}`, prepareTerm(v)];
+    })
+  );
+
+  const c = Check.fromString(code);
+  const unboundParams = c.unboundParameters();
+  const unboundScopeParams = c.unboundScopeParameters();
+
+  for (let p of unboundParams) {
+    c.set(p, params.get(p));
+  }
+
+  for (let p of unboundScopeParams) {
+    c.setScope(p, params.get(p));
+  }
+
+  return c;
+}
+
+export function policy(strings, ...values) {
+  let code = "";
+  for (let i = 0; i < strings.length; i++) {
+    code += strings[i];
+    if (i < values.length) {
+      code += `{_param_${i}}`;
+    }
+  }
+
+  const params = new Map(
+    values.map((v, i) => {
+      return [`_param_${i}`, prepareTerm(v)];
+    })
+  );
+
+  const pol = Policy.fromString(code);
+  const unboundParams = pol.unboundParameters();
+  const unboundScopeParams = pol.unboundScopeParameters();
+
+  for (let p of unboundParams) {
+    pol.set(p, params.get(p));
+  }
+
+  for (let p of unboundScopeParams) {
+    pol.setScope(p, params.get(p));
+  }
+
+  return pol;
 }

--- a/snippets/tagged-templates.js
+++ b/snippets/tagged-templates.js
@@ -71,32 +71,22 @@ export function rule(strings, ...values) {
     }
   }
 
-  const termParameters = values.map((v, i) => {
-    return [`_param_${i}`, prepareTerm(v)];
-  });
-
-  const isKeyParam = (v) => {
-    return (
-      (typeof v === "string" && v.startsWith("ed25519/")) ||
-      v.toDatalogParameter
-    );
-  };
-
-  const keyParameters = values
-    .map((v, i) => [i, v])
-    .filter(([i, v]) => isKeyParam(v))
-    .map(([i, v]) => {
+  const params = new Map(
+    values.map((v, i) => {
       return [`_param_${i}`, prepareTerm(v)];
-    });
+    })
+  );
 
   const r = Rule.fromString(code);
+  const unboundParams = r.unboundParameters();
+  const unboundScopeParams = r.unboundScopeParameters();
 
-  for (let p of termParameters) {
-    r.set(p[0], p[1]);
+  for (let p of unboundParams) {
+    r.set(p, params.get(p));
   }
 
-  for (let p of keyParameters) {
-    r.setScope(p[0], p[1]);
+  for (let p of unboundScopeParams) {
+    r.setScope(p, params.get(p));
   }
 
   return r;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use biscuit_auth as biscuit;
 use js_sys::Array;
@@ -187,6 +187,17 @@ impl Fact {
             .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
+    #[wasm_bindgen(js_name = unboundParameters)]
+    pub fn unbound_parameters(&self) -> Array {
+        let array = Array::new();
+        for (k, v) in self.0.parameters.as_ref().unwrap_or(&HashMap::new()) {
+            if v.is_none() {
+                array.push(&JsValue::from_str(&k));
+            }
+        }
+        array
+    }
+
     #[wasm_bindgen(js_name = set)]
     pub fn set(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
         let value = js_to_term(value)?;
@@ -274,12 +285,57 @@ impl Check {
             .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
+    #[wasm_bindgen(js_name = unboundParameters)]
+    pub fn unbound_parameters(&self) -> Array {
+        let mut params = BTreeSet::new();
+        let array = Array::new();
+        for q in self.0.queries.iter() {
+            if let Some(ps) = q.parameters.as_ref() {
+                for (k, v) in ps {
+                    if v.is_none() {
+                        if params.insert(k.to_string()) {
+                            array.push(&JsValue::from_str(&k));
+                        }
+                    }
+                }
+            }
+        }
+        array
+    }
+
+    #[wasm_bindgen(js_name = unboundScopeParameters)]
+    pub fn unbound_scope_parameters(&self) -> Array {
+        let mut params = BTreeSet::new();
+        let array = Array::new();
+        for q in self.0.queries.iter() {
+            if let Some(ps) = q.scope_parameters.as_ref() {
+                for (k, v) in ps {
+                    if v.is_none() {
+                        if params.insert(k.to_string()) {
+                            array.push(&JsValue::from_str(&k));
+                        }
+                    }
+                }
+            }
+        }
+        array
+    }
+
     #[wasm_bindgen(js_name = set)]
     pub fn set(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
         let value = js_to_term(value)?;
 
         self.0
             .set(name, value)
+            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
+    }
+
+    #[wasm_bindgen(js_name = setScope)]
+    pub fn set_scope(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
+        let value: PublicKey = serde_wasm_bindgen::from_value(value)?;
+
+        self.0
+            .set_scope(name, value.0)
             .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
@@ -302,12 +358,57 @@ impl Policy {
             .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
+    #[wasm_bindgen(js_name = unboundParameters)]
+    pub fn unbound_parameters(&self) -> Array {
+        let mut params = BTreeSet::new();
+        let array = Array::new();
+        for q in self.0.queries.iter() {
+            if let Some(ps) = q.parameters.as_ref() {
+                for (k, v) in ps {
+                    if v.is_none() {
+                        if params.insert(k.to_string()) {
+                            array.push(&JsValue::from_str(&k));
+                        }
+                    }
+                }
+            }
+        }
+        array
+    }
+
+    #[wasm_bindgen(js_name = unboundScopeParameters)]
+    pub fn unbound_scope_parameters(&self) -> Array {
+        let mut params = BTreeSet::new();
+        let array = Array::new();
+        for q in self.0.queries.iter() {
+            if let Some(ps) = q.scope_parameters.as_ref() {
+                for (k, v) in ps {
+                    if v.is_none() {
+                        if params.insert(k.to_string()) {
+                            array.push(&JsValue::from_str(&k));
+                        }
+                    }
+                }
+            }
+        }
+        array
+    }
+
     #[wasm_bindgen(js_name = set)]
     pub fn set(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
         let value = js_to_term(value)?;
 
         self.0
             .set(name, value)
+            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
+    }
+
+    #[wasm_bindgen(js_name = setScope)]
+    pub fn set_scope(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
+        let value: PublicKey = serde_wasm_bindgen::from_value(value)?;
+
+        self.0
+            .set_scope(name, value.0)
             .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use biscuit_auth as biscuit;
+use js_sys::Array;
 use serde::{de::Visitor, Deserialize};
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use time::OffsetDateTime;
@@ -214,12 +215,34 @@ impl Rule {
             .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
+    #[wasm_bindgen(js_name = unboundParameters)]
+    pub fn unbound_parameters(&self) -> Array {
+        let array = Array::new();
+        for (k, v) in self.0.parameters.as_ref().unwrap_or(&HashMap::new()) {
+            if v.is_none() {
+                array.push(&JsValue::from_str(&k));
+            }
+        }
+        array
+    }
+
+    #[wasm_bindgen(js_name = unboundScopeParameters)]
+    pub fn unbound_scope_parameters(&self) -> Array {
+        let array = Array::new();
+        for (k, v) in self.0.scope_parameters.as_ref().unwrap_or(&HashMap::new()) {
+            if v.is_none() {
+                array.push(&JsValue::from_str(&k));
+            }
+        }
+        array
+    }
+
     #[wasm_bindgen(js_name = set)]
     pub fn set(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
         let value = js_to_term(value)?;
 
         self.0
-            .set_lenient(name, value)
+            .set(name, value)
             .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
@@ -228,7 +251,7 @@ impl Rule {
         let value: PublicKey = serde_wasm_bindgen::from_value(value)?;
 
         self.0
-            .set_scope_lenient(name, value.0)
+            .set_scope(name, value.0)
             .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -219,7 +219,7 @@ impl Rule {
         let value = js_to_term(value)?;
 
         self.0
-            .set(name, value)
+            .set_lenient(name, value)
             .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -223,6 +223,15 @@ impl Rule {
             .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
     }
 
+    #[wasm_bindgen(js_name = setScope)]
+    pub fn set_scope(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
+        let value: PublicKey = serde_wasm_bindgen::from_value(value)?;
+
+        self.0
+            .set_scope_lenient(name, value.0)
+            .map_err(|e| serde_wasm_bindgen::to_value(&e).unwrap())
+    }
+
     #[wasm_bindgen(js_name = toString)]
     pub fn to_string(&self) -> String {
         self.0.to_string()


### PR DESCRIPTION

Fixes #23 

Even though `biscuit`, `block` and `authorizer` allow modifying an
existing block when used in combination with `merge`, it is not
satisfying from a performance standpoint, so use of `add_*` functions
is still required.