### PR TITLE
Use hex encoding for revocation identifiers instead of b64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ impl Biscuit {
             .0
             .revocation_identifiers()
             .into_iter()
-            .map(|id| base64::encode_config(id, base64::URL_SAFE).into())
+            .map(|i| hex::encode(i).into())
             .collect();
         ids.into_boxed_slice()
     }


### PR DESCRIPTION
The CLI and the web components already use hex encoding for revocation ids