### PR TITLE
biscuit-wasm 0.6.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# `0.6.0-beta1`
+# `0.6.0-beta.2`
 
 - Bump biscuit-auth to `6.0.0` (#51, #54) (Geoffroy Couprie, Tomáš Čarnecký)
 

--- a/examples/frontend/package-lock.json
+++ b/examples/frontend/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../..": {
       "name": "@biscuit-auth/biscuit-wasm",
-      "version": "0.6.0-beta.1",
+      "version": "0.6.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "prettier": "^2.8.8"

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -28,7 +28,7 @@
     },
     "../..": {
       "name": "@biscuit-auth/biscuit-wasm",
-      "version": "0.6.0-beta.1",
+      "version": "0.6.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "prettier": "^2.8.8"

--- a/js-tests/package-lock.json
+++ b/js-tests/package-lock.json
@@ -24,7 +24,7 @@
     },
     "..": {
       "name": "@biscuit-auth/biscuit-wasm",
-      "version": "0.6.0-beta.1",
+      "version": "0.6.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "prettier": "^2.8.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@biscuit-auth/biscuit-wasm",
-  "version": "0.5.0",
+  "version": "0.6.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@biscuit-auth/biscuit-wasm",
-      "version": "0.5.0",
+      "version": "0.6.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "prettier": "^2.8.8"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@biscuit-auth/biscuit-wasm",
   "description": "WebAssembly wrapper for Biscuit authorization tokens",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- normalize repo url in package.json
- bump to beta.2 since a 0.6.0-beta.1 had been published already