### PR TITLE
Add sync and workerd entrypoints for Cloudflare runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,48 @@ module.exports = {
 };
 ```
 
+### Cloudflare Workers / workerd
+
+Cloudflare Workers and other `workerd`-style runtimes import `.wasm` assets as
+precompiled `WebAssembly.Module` objects instead of relying on bundler-managed
+WASM module imports. The default package entry remains the `wasm-pack --target bundler`
+output for browser and Node bundler use cases, but the package now also exposes
+runtime-specific entrypoints for manual initialization:
+
+```javascript
+import {
+  Biscuit,
+  KeyPair,
+  PrivateKey,
+  authorizer,
+  biscuit,
+  block,
+} from "@biscuit-auth/biscuit-wasm/workerd";
+```
+
+If your tooling does not honor the `workerd` export condition automatically, you
+can import the explicit `@biscuit-auth/biscuit-wasm/workerd` subpath.
+
+For runtimes that can provide a `WebAssembly.Module` directly, use the `sync`
+entrypoint and initialize the package yourself:
+
+```javascript
+import { readFileSync } from "node:fs";
+import {
+  Biscuit,
+  PrivateKey,
+  authorizer,
+  biscuit,
+  block,
+  initSync,
+} from "@biscuit-auth/biscuit-wasm/sync";
+
+const wasmBytes = readFileSync(
+  new URL("./node_modules/@biscuit-auth/biscuit-wasm/module/biscuit_bg.wasm", import.meta.url)
+);
+initSync(new WebAssembly.Module(wasmBytes));
+```
+
 ## License
 
 Licensed under the Apache 2.0 License.

--- a/js-tests/package.json
+++ b/js-tests/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node --experimental-wasm-modules index.js",
-    "test": "node --experimental-wasm-modules index.js"
+    "test": "node --experimental-wasm-modules index.js && node sync.js"
   },
   "author": "",
   "license": "MIT",

--- a/js-tests/sync.js
+++ b/js-tests/sync.js
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { webcrypto } from "node:crypto";
+import {
+  authorizer,
+  biscuit,
+  block,
+  Biscuit,
+  initSync,
+  KeyPair,
+  PrivateKey,
+} from "@biscuit-auth/biscuit-wasm/sync";
+import { test } from "tape";
+
+// necessary for esm support, see https://docs.rs/getrandom/latest/getrandom/#nodejs-es-module-support
+if (parseInt(process.version.match(/v(\d+)\.(\d+)\.(\d+)/)[1], 10) <= 18) {
+  globalThis.crypto = webcrypto;
+}
+
+const wasmBytes = readFileSync(
+  new URL(
+    "./node_modules/@biscuit-auth/biscuit-wasm/module/biscuit_bg.wasm",
+    import.meta.url
+  )
+);
+
+const wasmModule = new WebAssembly.Module(wasmBytes);
+initSync(wasmModule);
+initSync(wasmModule);
+
+test("manual sync initialization works with a precompiled wasm module", function (t) {
+  let pk = PrivateKey.fromString(
+    "ed25519-private/473b5189232f3f597b5c2f3f9b0d5e28b1ee4e7cce67ec6b7fbf5984157a6b97"
+  );
+  let root = KeyPair.fromPrivateKey(pk);
+
+  let id = "1234";
+  let token = biscuit`user(${id});`
+    .build(root.getPrivateKey())
+    .appendBlock(block`check if user($u)`);
+
+  let parsedToken = Biscuit.fromBase64(token.toBase64(), root.getPublicKey());
+  let policy = authorizer`allow if user(${id})`
+    .buildAuthenticated(parsedToken)
+    .authorize();
+
+  t.equal(policy, 0, "authorization succeeded");
+  t.end();
+});

--- a/package.json
+++ b/package.json
@@ -9,14 +9,18 @@
   },
   "scripts": {
     "build": "wasm-pack build --target bundler --out-dir module --out-name biscuit --scope biscuit-auth && npm run append-snippets",
-    "format": "prettier -w ./snippets",
-    "check-format": "prettier -c ./snippets",
-    "append-snippets": "npm run check-format && cat ./snippets/*.js >> module/biscuit.js && cat ./snippets/definitions/*.d.ts >> module/biscuit.d.ts",
+    "format": "prettier -w ./scripts ./snippets",
+    "check-format": "prettier -c ./scripts ./snippets",
+    "append-snippets": "npm run check-format && node ./scripts/prepare-package.mjs",
     "remove-pkg-cruft": "rm module/package.json module/.gitignore module/README.md",
     "prepare-package": "npm run build && npm run remove-pkg-cruft",
     "prepublishOnly": "npm run prepare-package"
   },
   "files": [
+    "module/init.js",
+    "module/sync.js",
+    "module/sync.d.ts",
+    "module/workerd.js",
     "module/biscuit_bg.wasm",
     "module/biscuit.js",
     "module/biscuit_bg.js",
@@ -26,7 +30,22 @@
   "main": "module/biscuit.js",
   "type": "module",
   "exports": {
-    "import": "./module/biscuit.js"
+    ".": {
+      "types": "./module/biscuit.d.ts",
+      "workerd": "./module/workerd.js",
+      "import": "./module/biscuit.js",
+      "default": "./module/biscuit.js"
+    },
+    "./sync": {
+      "types": "./module/sync.d.ts",
+      "default": "./module/sync.js"
+    },
+    "./workerd": {
+      "types": "./module/biscuit.d.ts",
+      "default": "./module/workerd.js"
+    },
+    "./module/biscuit_bg.js": "./module/biscuit_bg.js",
+    "./module/biscuit_bg.wasm": "./module/biscuit_bg.wasm"
   },
   "module": "module/biscuit.js",
   "sideEffects": "false",

--- a/scripts/prepare-package.mjs
+++ b/scripts/prepare-package.mjs
@@ -1,0 +1,96 @@
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const rootDir = new URL("../", import.meta.url);
+
+function read(relativePath) {
+  return readFileSync(new URL(relativePath, rootDir), "utf8");
+}
+
+function write(relativePath, contents) {
+  writeFileSync(new URL(relativePath, rootDir), contents);
+}
+
+function withTrailingNewline(contents) {
+  return contents.endsWith("\n") ? contents : `${contents}\n`;
+}
+
+function listSnippetModules(dirPath) {
+  const moduleSnippetDir = new URL(dirPath, rootDir);
+  const stack = [moduleSnippetDir.pathname];
+  const modulePaths = [];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const entryPath = join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+        continue;
+      }
+
+      if (!entry.isFile() || !entry.name.endsWith(".js")) {
+        continue;
+      }
+
+      const relPath = relative(moduleSnippetDir.pathname, entryPath).replaceAll(
+        "\\",
+        "/"
+      );
+      modulePaths.push(`./snippets/${relPath}`);
+    }
+  }
+
+  return modulePaths.sort();
+}
+
+function renderTemplate(relativePath, replacements) {
+  let contents = read(relativePath);
+  for (const [token, value] of Object.entries(replacements)) {
+    contents = contents.replaceAll(token, value);
+  }
+  return contents;
+}
+
+const helperSnippets = [
+  read("snippets/biscuit-express.js"),
+  read("snippets/tagged-templates.js"),
+].map(withTrailingNewline);
+const helperDefinitions = [
+  read("snippets/definitions/biscuit-express.d.ts"),
+  read("snippets/definitions/tagged-templates.d.ts"),
+].map(withTrailingNewline);
+const snippetModules = JSON.stringify(
+  listSnippetModules("module/snippets"),
+  null,
+  2
+);
+
+const biscuitJs =
+  withTrailingNewline(read("module/biscuit.js")) + helperSnippets.join("\n");
+write("module/biscuit.js", biscuitJs);
+
+const biscuitDts =
+  withTrailingNewline(read("module/biscuit.d.ts")) +
+  helperDefinitions.join("\n");
+write("module/biscuit.d.ts", biscuitDts);
+
+const initJs = renderTemplate("snippets/runtime/init.js", {
+  __SNIPPET_MODULES__: snippetModules,
+});
+write("module/init.js", withTrailingNewline(initJs));
+
+const syncJs =
+  withTrailingNewline(read("snippets/runtime/sync.js")) +
+  helperSnippets.join("\n");
+write("module/sync.js", syncJs);
+
+const syncDts =
+  withTrailingNewline(read("snippets/definitions/sync.d.ts")) +
+  withTrailingNewline(read("module/biscuit.d.ts"));
+write("module/sync.d.ts", syncDts);
+
+const workerdJs =
+  withTrailingNewline(read("snippets/runtime/workerd.js")) +
+  helperSnippets.join("\n");
+write("module/workerd.js", workerdJs);

--- a/snippets/definitions/sync.d.ts
+++ b/snippets/definitions/sync.d.ts
@@ -1,0 +1,3 @@
+export function initSync(
+  moduleOrBytes: WebAssembly.Module | ArrayBuffer | Uint8Array
+): void;

--- a/snippets/runtime/init.js
+++ b/snippets/runtime/init.js
@@ -1,0 +1,44 @@
+import * as bg from "./biscuit_bg.js";
+
+const wasmImports = {};
+for (const [key, value] of Object.entries(bg)) {
+  if (key.startsWith("__wbg_") || key.startsWith("__wbindgen_")) {
+    wasmImports[key] = value;
+  }
+}
+
+const snippetExports = {
+  performance_now: () => globalThis.performance.now(),
+};
+const snippetModules = __SNIPPET_MODULES__;
+
+let initialized = false;
+
+function toWasmModule(moduleOrBytes) {
+  if (moduleOrBytes instanceof WebAssembly.Module) {
+    return moduleOrBytes;
+  }
+
+  return new WebAssembly.Module(moduleOrBytes);
+}
+
+export function initSync(moduleOrBytes) {
+  if (initialized) {
+    return;
+  }
+
+  const imports = {
+    "./biscuit_bg.js": wasmImports,
+  };
+  for (const path of snippetModules) {
+    imports[path] = snippetExports;
+  }
+
+  const instance = new WebAssembly.Instance(
+    toWasmModule(moduleOrBytes),
+    imports
+  );
+  bg.__wbg_set_wasm(instance.exports);
+  instance.exports.__wbindgen_start();
+  initialized = true;
+}

--- a/snippets/runtime/sync.js
+++ b/snippets/runtime/sync.js
@@ -1,0 +1,2 @@
+export * from "./biscuit_bg.js";
+export { initSync } from "./init.js";

--- a/snippets/runtime/workerd.js
+++ b/snippets/runtime/workerd.js
@@ -1,0 +1,6 @@
+import wasmModule from "./biscuit_bg.wasm";
+import { initSync } from "./init.js";
+
+export * from "./biscuit_bg.js";
+
+initSync(wasmModule);


### PR DESCRIPTION
## Summary

Cloudflare Workers and other `workerd`-style runtimes import `.wasm` assets as precompiled `WebAssembly.Module` objects, while this package currently only publishes the `wasm-pack --target bundler` entrypoint. That forces downstream consumers to patch the generated loader or maintain wrapper packages just to instantiate `biscuit-wasm` in Cloudflare-style runtimes.

This PR upstreams that runtime support without changing the existing bundler path.

- add a new `@biscuit-auth/biscuit-wasm/sync` entrypoint with `initSync(...)` for runtimes that can provide a precompiled `WebAssembly.Module` or raw wasm bytes
- add a `workerd` export condition plus an explicit `@biscuit-auth/biscuit-wasm/workerd` subpath that initializes from `biscuit_bg.wasm` automatically
- generate the manual-init runtime files during `prepare-package`, discovering snippet import paths from the built package instead of hardcoding wasm-bindgen hash directories in source
- expose `./module/biscuit_bg.js` and `./module/biscuit_bg.wasm` subpaths for custom loaders, and document the new runtime options in the README
- add a JS regression test that exercises the new `sync` entry against a precompiled `WebAssembly.Module`

## Test plan
- [x] `npm run check-format`
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `npm run prepare-package`
- [x] `cd js-tests && npm install && npm test`
- [x] `cd examples/node && npm install && npm start`